### PR TITLE
More runtime configuration possibilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,10 @@ settings.json
 
 # Program output
 *.avi
-camera_calib.txt
+calib/**
+
+# Patterns
+patterns
+
+# tmp files
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 LIBS= -lm -largtable2
-CXXFLAGS= -fPIC -I. -I./srcChroma -I./ext/include -O3 -Wall -pedantic -std=c++11
+CXXFLAGS= -fPIC -I. -I./srcChroma -I./ext/include -g -Og -Wall -pedantic -std=c++11
 #CXXFLAGS= -fPIC -g -ggdb -I. -Wall -W -lm -std=c++11
 RM=rm -f
 DEMOFLAGS= -lGL -lGLEW `sdl-config --cflags --libs`

--- a/src/defines.h
+++ b/src/defines.h
@@ -48,7 +48,7 @@
 
 
 #ifndef HAVE_FIREWIRE_LIB
-//#define HAVE_FIREWIRE_LIB
+#define HAVE_FIREWIRE_LIB
 #endif
 
 #define UMF_DEBUG

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@
 #include "util/homography2d.h"
 #include "util/chromakey.h"
 #include "util/calibration.h"
+#include "util/successlogger.h"
 
 #include "chroma.hpp"
 #include "util/native_x.h"
@@ -79,101 +80,6 @@ using namespace umf;
 #ifndef M_PI_4
 #define M_PI_4 0.78539816339744830961566084581988
 #endif
-
-
-class SuccessLogger {
-public:
-    SuccessLogger(float fps = 20) {
-        this->current = 1;
-        this->onepfps = 1000.0f/fps;
-        this->detectSum = 0;
-    }
-    
-    void detectStart()
-    {
-        this->timer.start();
-    }
-
-    void addFailure()
-    {
-        //std::cout << "Failure." << std::endl;
-        this->detectSum += (std::max)(0.0, this->timer.stop() - this->onepfps);
-    }
-    
-    void addSuccess(int frameId)
-    {
-        //std::cout << "Success." << std::endl;
-		this->detectSum += this->timer.stop();
-        int diff = frameId - current - 1;
-        //frameDiffs.push_back(diff*onepfps + detectSum);
-        frameDiffs.push_back(diff);
-        this->detectSum = 0;
-        this->current = frameId;
-    }
-
-    void store(std::string outDir, std::string filename_short);
-
-private:
-    std::vector<int> frameDiffs;
-    Timer timer;
-    float onepfps;
-    int current;
-    double detectSum;
-};
-
-void SuccessLogger::store(std::string outDir, std::string filename_short)
-{
-    std::string diff_name = outDir + filename_short + std::string(".diffs.txt");
-    std::sort(this->frameDiffs.begin(), this->frameDiffs.end());
-    std::fstream successOut(diff_name.c_str(), std::fstream::out);
-    double fullSize = this->frameDiffs.size();
-    int index = 0;
-    for(std::vector<int>::iterator it = this->frameDiffs.begin(); it != this->frameDiffs.end(); it++, index++)
-    {
-        successOut << *it << " " << index/fullSize << std::endl;
-    }
-    successOut.close();
-
-    std::fstream successOutPlot((diff_name + std::string(".p")).c_str(), std::fstream::out);
-
-    successOutPlot << "set key right bottom \n";
-    successOutPlot << "set auto\n";
-    successOutPlot << "\n";
-
-
-    successOutPlot << "set style line 1 lt 1 lw 1 lc rgb \"red\"\n";
-    successOutPlot << "set style line 2 lt 2 lw 1 lc rgb \"green\"\n";
-    successOutPlot << "set style line 3 lt 3 lw 1 lc rgb \"blue\"\n";
-    successOutPlot << "set style line 4 lt 4 lw 1 lc rgb \"purple\"\n";
-    successOutPlot << "set style line 5 lt 5 lw 1 lc rgb \"cyan\"\n";
-    successOutPlot << "set style line 6 lt 6 lw 1 lc rgb \"orange\"\n";
-
-    successOutPlot << "set lmargin 5.0\n";
-    successOutPlot << "set bmargin 2.5\n";
-    successOutPlot << "set rmargin 0.5\n";
-    successOutPlot << "set tmargin 0.5\n";
-
-    successOutPlot << "\n";
-    successOutPlot << "set xrange[0:20]\n";
-    successOutPlot << "set yrange[0: 1]\n";
-    successOutPlot << "set xtics 5\n";
-
-    successOutPlot << "\n";
-    successOutPlot << "# Make some suitable labels.\n";
-    //successOutPlot << "set notitle\n";
-    successOutPlot << "set xlabel \"Missed frame count\" offset 0.0, 0.5\n";
-    successOutPlot << "set ylabel \"Probability distribution\" offset 2.7, 0.0\n";
-    successOutPlot << "set terminal postscript eps enhanced color \"Times-Roman\" 25\n";
-    successOutPlot << "set output '| epstopdf --filter --outfile=" << (diff_name + std::string(".pdf")) << "'\n";
-
-
-    successOutPlot << " plot '" << diff_name << "' using 1:2 title '"<< filename_short << "' with lines\n";
-
-    successOutPlot << "\n";
-    successOutPlot.close();
-}
-
-
 
 char *loadFile(const char* filename)
 {

--- a/src/util/firewire_factory.cpp
+++ b/src/util/firewire_factory.cpp
@@ -67,7 +67,7 @@ static const char* framerateMapping[DC1394_FRAMERATE_NUM] = {
  *
  * docs see here: http://damien.douxchamps.net/ieee1394/libdc1394/
  */
-int FirewireFactory::init(void *) {
+int FirewireFactory::init(void * data) {
 
     dc1394camera_list_t * list;
     dc1394error_t err;
@@ -88,6 +88,17 @@ int FirewireFactory::init(void *) {
 
     if (list->num == 0) {
         dc1394_log_error("No cameras found");
+        return EXIT_FAILURE;
+    }
+
+    int cameraNum = 0;
+    if(data) {
+        CVImageInitStruct *p = (CVImageInitStruct *) data;    
+        cameraNum = p->cameraIndex;
+    }
+
+    if (list->num <= cameraNum) {
+        dc1394_log_error("No cameras with given index %d, only have %d cameras.", cameraNum, list->num);
         return EXIT_FAILURE;
     }
 

--- a/src/util/firewire_factory.h
+++ b/src/util/firewire_factory.h
@@ -2,6 +2,7 @@
 #define __UMF_UTIL_FIREWIRE_FACTORY_H__
 
 #include "stream_factory.h"
+#include "../defines.h"
 
 #ifdef HAVE_FIREWIRE_LIB
 

--- a/src/util/opencv_factory.h
+++ b/src/util/opencv_factory.h
@@ -15,15 +15,6 @@
 namespace umf
 {
 
-typedef struct
-{
-    bool file;
-    std::string filename;
-    int cameraIndex;
-	int width;
-	int height;
-} CVImageInitStruct;
-
 /**
  * Load images, videos or camera using OpenCV library
  */

--- a/src/util/stream_factory.h
+++ b/src/util/stream_factory.h
@@ -9,6 +9,15 @@ using namespace std;
 
 namespace umf {
 
+typedef struct
+{
+    bool file;
+    std::string filename;
+    int cameraIndex;
+	int width;
+	int height;
+} CVImageInitStruct;
+
 // Abstract base class for accessing images
 class UMF ImageFactory {
 public:

--- a/src/util/successlogger.cpp
+++ b/src/util/successlogger.cpp
@@ -1,0 +1,55 @@
+#include "successlogger.h"
+#include <string>
+#include <fstream>
+
+void SuccessLogger::store(std::string outDir, std::string filename_short)
+{
+    std::string diff_name = outDir + filename_short + std::string(".diffs.txt");
+    std::sort(this->frameDiffs.begin(), this->frameDiffs.end());
+    std::fstream successOut(diff_name.c_str(), std::fstream::out);
+    double fullSize = this->frameDiffs.size();
+    int index = 0;
+    for(std::vector<int>::iterator it = this->frameDiffs.begin(); it != this->frameDiffs.end(); it++, index++)
+    {
+        successOut << *it << " " << index/fullSize << std::endl;
+    }
+    successOut.close();
+
+    std::fstream successOutPlot((diff_name + std::string(".p")).c_str(), std::fstream::out);
+
+    successOutPlot << "set key right bottom \n";
+    successOutPlot << "set auto\n";
+    successOutPlot << "\n";
+
+
+    successOutPlot << "set style line 1 lt 1 lw 1 lc rgb \"red\"\n";
+    successOutPlot << "set style line 2 lt 2 lw 1 lc rgb \"green\"\n";
+    successOutPlot << "set style line 3 lt 3 lw 1 lc rgb \"blue\"\n";
+    successOutPlot << "set style line 4 lt 4 lw 1 lc rgb \"purple\"\n";
+    successOutPlot << "set style line 5 lt 5 lw 1 lc rgb \"cyan\"\n";
+    successOutPlot << "set style line 6 lt 6 lw 1 lc rgb \"orange\"\n";
+
+    successOutPlot << "set lmargin 5.0\n";
+    successOutPlot << "set bmargin 2.5\n";
+    successOutPlot << "set rmargin 0.5\n";
+    successOutPlot << "set tmargin 0.5\n";
+
+    successOutPlot << "\n";
+    successOutPlot << "set xrange[0:20]\n";
+    successOutPlot << "set yrange[0: 1]\n";
+    successOutPlot << "set xtics 5\n";
+
+    successOutPlot << "\n";
+    successOutPlot << "# Make some suitable labels.\n";
+    //successOutPlot << "set notitle\n";
+    successOutPlot << "set xlabel \"Missed frame count\" offset 0.0, 0.5\n";
+    successOutPlot << "set ylabel \"Probability distribution\" offset 2.7, 0.0\n";
+    successOutPlot << "set terminal postscript eps enhanced color \"Times-Roman\" 25\n";
+    successOutPlot << "set output '| epstopdf --filter --outfile=" << (diff_name + std::string(".pdf")) << "'\n";
+
+
+    successOutPlot << " plot '" << diff_name << "' using 1:2 title '"<< filename_short << "' with lines\n";
+
+    successOutPlot << "\n";
+    successOutPlot.close();
+}

--- a/src/util/successlogger.h
+++ b/src/util/successlogger.h
@@ -1,0 +1,49 @@
+#ifndef _UMF_SUCCESSLOGGER_H_
+#define _UMF_SUCCESSLOGGER_H_
+
+#include <vector>
+#include "../umf.h"
+
+using namespace umf;
+
+class SuccessLogger {
+public:
+    SuccessLogger(float fps = 20) {
+        this->current = 1;
+        this->onepfps = 1000.0f/fps;
+        this->detectSum = 0;
+    }
+    
+    void detectStart()
+    {
+        this->timer.start();
+    }
+
+    void addFailure()
+    {
+        //std::cout << "Failure." << std::endl;
+        this->detectSum += (std::max)(0.0, this->timer.stop() - this->onepfps);
+    }
+    
+    void addSuccess(int frameId)
+    {
+        //std::cout << "Success." << std::endl;
+		this->detectSum += this->timer.stop();
+        int diff = frameId - current - 1;
+        //frameDiffs.push_back(diff*onepfps + detectSum);
+        frameDiffs.push_back(diff);
+        this->detectSum = 0;
+        this->current = frameId;
+    }
+
+    void store(std::string outDir, std::string filename_short);
+
+private:
+    std::vector<int> frameDiffs;
+    Timer timer;
+    float onepfps;
+    int current;
+    double detectSum;
+};
+
+#endif


### PR DESCRIPTION
This change allows to compile umf-detector with

* OpenCV **and** FireWire support
* support for gray (1 channel) **and** RGB (3 channel) detectors.

all compiled and linked at the same time. The proper configuration is chosen at runtime by the following parameters:

  -i, -I input_video        the input video or image used for processing. Use **'firewire'**, possibly together with '-k', to select that source.
  -a, -A, --alg=algorithm   Choose the algorithm [sog (default), **rgb**, chroma]
  -k, -K, --camera=<int>    the index of the webcam to use, starting from 0

Note that the rgb algorithm seems to be under development and does not yet work, even though you can now select it.